### PR TITLE
Implemention of inspection #KT-15537

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -3286,6 +3286,15 @@
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ReplaceIntRangeStartEndInclusiveWithFirstLastInspection"
+                     displayName="Replace IntRange 'start' or 'endInclusive' with kotlin.collections 'first' or'last'"
+                     groupPath="Kotlin"
+                     groupName="Style issues"
+                     enabledByDefault="true"
+                     level="WEAK WARNING"
+                     language="kotlin"
+    />
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.RedundantRequireNotNullCallInspection"
                      displayName="Redundant 'requireNotNull' or 'checkNotNull' call"
                      groupPath="Kotlin"

--- a/idea/resources/inspectionDescriptions/ReplaceIntRangeStartEndInclusiveWithFirstLast.html
+++ b/idea/resources/inspectionDescriptions/ReplaceIntRangeStartEndInclusiveWithFirstLast.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+This inspection reports usages of <code>IntRange</code> <code>start</code> and <code>endInclusive</code>. These properties can be replaced with <code>kotlin.collections</code> <code>first</code> and <code>last</code>.
+Example: <b>range.start</b> can be replaced with <b>range.first</b>.
+</body>
+</html>

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceIntRangeStartEndInclusiveWithFirstLastInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ReplaceIntRangeStartEndInclusiveWithFirstLastInspection.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElementVisitor
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
+
+class ReplaceIntRangeStartEndInclusiveWithFirstLastInspection : AbstractKotlinInspection() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return dotQualifiedExpressionVisitor { expression ->
+            val fName: FqName = expression.getFunctionName() ?: return@dotQualifiedExpressionVisitor
+
+            if (fName.isStart()) {
+                holder.registerProblem(
+                    expression,
+                    "Could be replaced with `first`",
+                    ReplaceIntRangeStartWithFirstQuickFix()
+                )
+            } else if (fName.isEndInclusive()) {
+                holder.registerProblem(
+                    expression,
+                    "Could be replaced with `last`",
+                    ReplaceIntRangeEndInclusiveWithLastQuickFix()
+                )
+            }
+        }
+    }
+}
+
+private fun KtDotQualifiedExpression.getFunctionName(): FqName? {
+    val context = this.analyze()
+    return this.getResolvedCall(context)?.resultingDescriptor?.fqNameOrNull()
+}
+
+private fun FqName.isStart(): Boolean {
+    return this == FqName("kotlin.ranges.IntRange.start")
+}
+
+private fun FqName.isEndInclusive(): Boolean {
+    return this == FqName("kotlin.ranges.IntRange.endInclusive")
+}
+
+class ReplaceIntRangeStartWithFirstQuickFix : LocalQuickFix {
+    override fun getName() = "Replace 'start' with 'first'"
+
+    override fun getFamilyName() = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val element = descriptor.psiElement as KtDotQualifiedExpression
+        val selector = element.selectorExpression ?: return
+        selector.replace(KtPsiFactory(element).createExpression("first"))
+    }
+}
+
+class ReplaceIntRangeEndInclusiveWithLastQuickFix : LocalQuickFix {
+    override fun getName() = "Replace 'endInclusive' with 'last'"
+
+    override fun getFamilyName() = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val element = descriptor.psiElement as KtDotQualifiedExpression
+        val selector = element.selectorExpression ?: return
+        selector.replace(KtPsiFactory(element).createExpression("last"))
+    }
+}

--- a/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/.inspection
+++ b/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.inspections.ReplaceIntRangeStartEndInclusiveWithFirstLastInspection

--- a/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/endInclusiveCharRange.kt
+++ b/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/endInclusiveCharRange.kt
@@ -1,0 +1,7 @@
+// PROBLEM: none
+// WITH_RUNTIME
+
+fun foo() {
+    var range : CharRange = 'a' .. 'z'
+    range.<caret>endInclusive
+}

--- a/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/endInclusiveIntRange.kt
+++ b/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/endInclusiveIntRange.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : IntRange = 1..2
+    range.<caret>endInclusive
+}

--- a/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/endInclusiveIntRange.kt.after
+++ b/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/endInclusiveIntRange.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : IntRange = 1..2
+    range.last
+}

--- a/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/endInclusiveLongRange.kt
+++ b/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/endInclusiveLongRange.kt
@@ -1,0 +1,7 @@
+// PROBLEM: none
+// WITH_RUNTIME
+
+fun foo() {
+    var range : LongRange = 1L..2L
+    range.<caret>endInclusive
+}

--- a/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/startCharRange.kt
+++ b/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/startCharRange.kt
@@ -1,0 +1,7 @@
+// PROBLEM: none
+// WITH_RUNTIME
+
+fun foo() {
+    var range : CharRange  = 'a' .. 'z'
+    range.<caret>start
+}

--- a/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/startIntRange.kt
+++ b/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/startIntRange.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : IntRange = 1..2
+    range.<caret>start
+}

--- a/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/startIntRange.kt.after
+++ b/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/startIntRange.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+
+fun foo() {
+    var range : IntRange = 1..2
+    range.first
+}

--- a/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/startLongRange.kt
+++ b/idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/startLongRange.kt
@@ -1,0 +1,7 @@
+// PROBLEM: none
+// WITH_RUNTIME
+
+fun foo() {
+    var range : LongRange = 1L..2L
+    range.<caret>start
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -6569,6 +6569,49 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         }
     }
 
+    @TestMetadata("idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ReplaceIntRangeStartEndInclusiveWithFirstLast extends AbstractLocalInspectionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInReplaceIntRangeStartEndInclusiveWithFirstLast() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("endInclusiveCharRange.kt")
+        public void testEndInclusiveCharRange() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/endInclusiveCharRange.kt");
+        }
+
+        @TestMetadata("endInclusiveIntRange.kt")
+        public void testEndInclusiveIntRange() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/endInclusiveIntRange.kt");
+        }
+
+        @TestMetadata("endInclusiveLongRange.kt")
+        public void testEndInclusiveLongRange() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/endInclusiveLongRange.kt");
+        }
+
+        @TestMetadata("startCharRange.kt")
+        public void testStartCharRange() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/startCharRange.kt");
+        }
+
+        @TestMetadata("startIntRange.kt")
+        public void testStartIntRange() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/startIntRange.kt");
+        }
+
+        @TestMetadata("startLongRange.kt")
+        public void testStartLongRange() throws Exception {
+            runTest("idea/testData/inspectionsLocal/replaceIntRangeStartEndInclusiveWithFirstLast/startLongRange.kt");
+        }
+    }
+
     @TestMetadata("idea/testData/inspectionsLocal/replaceCollectionCountWithSize")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
This inspection reports usages of IntRange IntRange and endInclusive. These properties can be replaced with equivalent kotlin.collections first and last.
Example: range.start() can be replaced with range.first()

**Issue:**
https://youtrack.jetbrains.com/issue/KT-15537