### PR TITLE
KT-22880: Add 'convert to object' inspection

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -1793,6 +1793,15 @@
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ConvertToObjectDeclarationInspection"
+                     displayName="Class containing only a companion object can be converted to object declaration"
+                     groupPath="Kotlin"
+                     groupName="Style issues"
+                     enabledByDefault="true"
+                     level="INFO"
+                     language="kotlin"
+    />
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.conventionNameCalls.ReplaceGetOrSetInspection"
                      displayName="Explicit 'get' or 'set' call"
                      groupPath="Kotlin"

--- a/idea/resources/inspectionDescriptions/ConvertToObjectDeclaration.html
+++ b/idea/resources/inspectionDescriptions/ConvertToObjectDeclaration.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection reports classes containing only companion objects.
+</body>
+</html>

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ConvertToObjectDeclarationInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ConvertToObjectDeclarationInspection.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.LocalInspectionToolSession
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElementFactory
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.impl.PsiElementFactoryImpl
+import com.intellij.psi.search.searches.ReferencesSearch
+import org.jetbrains.kotlin.idea.caches.resolve.analyze
+import org.jetbrains.kotlin.idea.findUsages.processAllUsages
+import org.jetbrains.kotlin.idea.references.KtSimpleNameReference
+import org.jetbrains.kotlin.lexer.KtKeywordToken
+import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.synthetics.findClassDescriptor
+import org.jetbrains.kotlin.resolve.descriptorUtil.getAllSuperClassifiers
+import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperClassNotAny
+import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperInterfaces
+
+class ConvertToObjectDeclarationInspection : AbstractKotlinInspection() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean, session: LocalInspectionToolSession): PsiElementVisitor {
+        return classVisitor { clazz ->
+            val descriptor = clazz.findClassDescriptor(clazz.analyze())
+            if (descriptor.getSuperClassNotAny() != null || descriptor.getSuperInterfaces().isNotEmpty()) return@classVisitor
+            val declarations = clazz.declarations
+            if (declarations.size == 1) {
+                val firstDecl = declarations[0] as? KtObjectDeclaration ?: return@classVisitor
+                if (firstDecl.isCompanion() && firstDecl.nameIdentifier == null) {
+                    holder.registerProblem(
+                        clazz,
+                        "Can be converted to object declaration",
+                        ConvertToObjectDeclarationFix()
+                    )
+                }
+            }
+        }
+    }
+
+    private class ConvertToObjectDeclarationFix : LocalQuickFix {
+        override fun getFamilyName() = "Convert to object declaration"
+
+        override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+            val clazz = descriptor.psiElement as? KtClass ?: return
+            val obj = clazz.declarations[0] as? KtObjectDeclaration ?: return
+            removeCompanionReference(clazz)
+
+            obj.setName(clazz.name!!)
+            obj.removeModifier(KtTokens.COMPANION_KEYWORD)
+            clazz.replace(obj)
+        }
+
+        private fun removeCompanionReference(clazz: KtClass) {
+            val currentCompanion = clazz.companionObjects.first()
+            ReferencesSearch.search(currentCompanion).forEach { ref ->
+                val dotQualified = ref.element.parent as? KtDotQualifiedExpression ?: return@forEach
+                if (dotQualified.selectorExpression?.text == "Companion") {
+                    dotQualified.replace(dotQualified.receiverExpression)
+                }
+            }
+        }
+    }
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/.inspection
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.inspections.ConvertToObjectDeclarationInspection

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/accompanyingDeclarations.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/accompanyingDeclarations.kt
@@ -1,0 +1,7 @@
+// PROBLEM: none
+class <caret>A {
+    companion object {
+        const val name = "A"
+    }
+    val test = "B"
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/accompanyingNonDeclarations.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/accompanyingNonDeclarations.kt
@@ -1,0 +1,9 @@
+// PROBLEM: none
+class <caret>A {
+    companion object {
+        const val name = "A"
+    }
+    init {
+
+    }
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/existingSuper.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/existingSuper.kt
@@ -1,0 +1,10 @@
+// PROBLEM: none
+
+open class A {}
+open class B {}
+
+class <caret>Test : A() {
+    companion object : B() {
+
+    }
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/inheritance.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/inheritance.kt
@@ -1,0 +1,16 @@
+// FIX: Convert to object declaration
+
+open class A {
+    open fun test() = "test"
+}
+
+interface TestInterface {
+    fun inherited(): String
+}
+
+class <caret>B {
+    companion object : A(), TestInterface {
+        override fun test() = "test2"
+        override fun inherited() = "inherited"
+    }
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/inheritance.kt.after
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/inheritance.kt.after
@@ -1,0 +1,14 @@
+// FIX: Convert to object declaration
+
+open class A {
+    open fun test() = "test"
+}
+
+interface TestInterface {
+    fun inherited(): String
+}
+
+object B : A(), TestInterface {
+    override fun test() = "test2"
+    override fun inherited() = "inherited"
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/named.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/named.kt
@@ -1,0 +1,8 @@
+// PROBLEM: none
+
+class <caret>NotificationItemTypeModel {
+    companion object Named {
+        const val ABC = "ABC"
+        const val CDE = "CDE"
+    }
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/refactorCompanionReference.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/refactorCompanionReference.kt
@@ -1,0 +1,13 @@
+// FIX: Convert to object declaration
+// WITH_RUNTIME
+
+class <caret>A {
+    companion object {
+        val prop = "test"
+    }
+}
+
+fun main() {
+    println(A.Companion.prop)
+    println(A.prop)
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/refactorCompanionReference.kt.after
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/refactorCompanionReference.kt.after
@@ -1,0 +1,11 @@
+// FIX: Convert to object declaration
+// WITH_RUNTIME
+
+object A {
+    val prop = "test"
+}
+
+fun main() {
+    println(A.prop)
+    println(A.prop)
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/simple.kt
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/simple.kt
@@ -1,0 +1,8 @@
+// FIX: Convert to object declaration
+
+class <caret>NotificationItemTypeModel {
+    companion object {
+        const val ABC = "ABC"
+        const val CDE = "CDE"
+    }
+}

--- a/idea/testData/inspectionsLocal/convertToObjectDeclaration/simple.kt.after
+++ b/idea/testData/inspectionsLocal/convertToObjectDeclaration/simple.kt.after
@@ -1,0 +1,6 @@
+// FIX: Convert to object declaration
+
+object NotificationItemTypeModel {
+    const val ABC = "ABC"
+    const val CDE = "CDE"
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -2123,6 +2123,54 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         }
     }
 
+    @TestMetadata("idea/testData/inspectionsLocal/convertToObjectDeclaration")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ConvertToObjectDeclaration extends AbstractLocalInspectionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        @TestMetadata("accompanyingDeclarations.kt")
+        public void testAccompanyingDeclarations() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/accompanyingDeclarations.kt");
+        }
+
+        @TestMetadata("accompanyingNonDeclarations.kt")
+        public void testAccompanyingNonDeclarations() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/accompanyingNonDeclarations.kt");
+        }
+
+        public void testAllFilesPresentInConvertToObjectDeclaration() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/convertToObjectDeclaration"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("existingSuper.kt")
+        public void testExistingSuper() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/existingSuper.kt");
+        }
+
+        @TestMetadata("inheritance.kt")
+        public void testInheritance() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/inheritance.kt");
+        }
+
+        @TestMetadata("named.kt")
+        public void testNamed() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/named.kt");
+        }
+
+        @TestMetadata("refactorCompanionReference.kt")
+        public void testRefactorCompanionReference() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/refactorCompanionReference.kt");
+        }
+
+        @TestMetadata("simple.kt")
+        public void testSimple() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertToObjectDeclaration/simple.kt");
+        }
+    }
+
     @TestMetadata("idea/testData/inspectionsLocal/copyWithoutNamedArguments")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
https://youtrack.jetbrains.com/issue/KT-22880

Converts a class with only a nameless Companion object in it to an object declaration. Also changes `MyClass.Companion` references to `MyClass`.