### PR TITLE
KT-26629 Inspection to replace `==` operator on Double.NaN with `equals` call

### DIFF
--- a/idea/resources/META-INF/plugin-common.xml
+++ b/idea/resources/META-INF/plugin-common.xml
@@ -2350,6 +2350,15 @@
                      language="kotlin"
     />
 
+    <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.ConvertEqualsDoubleNaNInspection"
+                     displayName="Convert '== Double.NaN' to 'equals' call"
+                     groupPath="Kotlin"
+                     groupName="Probable bugs"
+                     enabledByDefault="true"
+                     level="WARNING"
+                     language="kotlin"
+    />
+
     <localInspection implementationClass="org.jetbrains.kotlin.idea.inspections.UnusedEqualsInspection"
                      displayName="Unused equals expression"
                      groupPath="Kotlin"

--- a/idea/resources/inspectionDescriptions/ConvertEqualsDoubleNaN.html
+++ b/idea/resources/inspectionDescriptions/ConvertEqualsDoubleNaN.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This inspection reports <b>a == Double.NaN</b> which can be replaced with <b>a.isNaN()</b>.
+</body>
+</html>

--- a/idea/src/org/jetbrains/kotlin/idea/inspections/ConvertEqualsDoubleNaNInspection.kt
+++ b/idea/src/org/jetbrains/kotlin/idea/inspections/ConvertEqualsDoubleNaNInspection.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2010-2019 JetBrains s.r.o. Use of this source code is governed by the Apache 2.0 license
+ * that can be found in the license/LICENSE.txt file.
+ */
+
+package org.jetbrains.kotlin.idea.inspections
+
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElementVisitor
+import org.jetbrains.kotlin.idea.caches.resolve.resolveToCall
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameUnsafe
+
+class ConvertEqualsDoubleNaNInspection : AbstractKotlinInspection() {
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return binaryExpressionVisitor { expression ->
+            if (expression.left.isDoubleNaNExpression() || expression.right.isDoubleNaNExpression()) {
+                val inverted = when (expression.operationToken) {
+                    KtTokens.EXCLEQ -> true
+                    KtTokens.EQEQ -> false
+                    else -> return@binaryExpressionVisitor
+                }
+                holder.registerProblem(
+                    expression,
+                    "Equality check with NaN should be replaced with 'isNaN()'",
+                    ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+                    ConvertEqualsDoubleNaNQuickFix(inverted)
+                )
+            }
+        }
+    }
+}
+
+private class ConvertEqualsDoubleNaNQuickFix(val inverted: Boolean) : LocalQuickFix {
+    override fun getName() = "Replace with 'isNaN()'"
+
+    override fun getFamilyName() = name
+
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+        val element = descriptor.psiElement as? KtBinaryExpression ?: return
+
+        val other = when {
+            element.left.isDoubleNaNExpression() -> element.right ?: return
+            element.right.isDoubleNaNExpression() -> element.left ?: return
+            else -> return
+        }
+        val pattern = if (inverted) "!$0.isNaN()" else "$0.isNaN()"
+        element.replace(KtPsiFactory(element).createExpressionByPattern(pattern, other))
+    }
+}
+
+private val doubleNaNSet = setOf("kotlin.Double.Companion.NaN", "java.lang.Double.NaN")
+
+private fun KtExpression?.isDoubleNaNExpression(): Boolean {
+    val fqName = this?.resolveToCall()?.resultingDescriptor?.fqNameUnsafe?.asString()
+    return doubleNaNSet.contains(fqName)
+}

--- a/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/.inspection
+++ b/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/.inspection
@@ -1,0 +1,1 @@
+org.jetbrains.kotlin.idea.inspections.ConvertEqualsDoubleNaNInspection

--- a/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/importedProperty.kt
+++ b/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/importedProperty.kt
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+import kotlin.Double.Companion.NaN
+
+fun test() {
+    val t = NaN ==<caret> 5.0
+}

--- a/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/importedProperty.kt.after
+++ b/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/importedProperty.kt.after
@@ -1,0 +1,6 @@
+// WITH_RUNTIME
+import kotlin.Double.Companion.NaN
+
+fun test() {
+    val t = 5.0.isNaN()
+}

--- a/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/inequality.kt
+++ b/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/inequality.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun main() {
+    val result = 5.0 + 3.0 <caret>!= Double.NaN;
+}

--- a/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/inequality.kt.after
+++ b/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/inequality.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun main() {
+    val result = !(5.0 + 3.0).isNaN();
+}

--- a/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/javaDouble.kt
+++ b/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/javaDouble.kt
@@ -1,0 +1,5 @@
+// RUNTIME_WITH_FULL_JDK
+
+fun test() {
+    val t = java.lang.Double.NaN ==<caret> 5.0
+}

--- a/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/javaDouble.kt.after
+++ b/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/javaDouble.kt.after
@@ -1,0 +1,5 @@
+// RUNTIME_WITH_FULL_JDK
+
+fun test() {
+    val t = 5.0.isNaN()
+}

--- a/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/negative.kt
+++ b/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/negative.kt
@@ -1,0 +1,11 @@
+// WITH_RUNTIME
+// PROBLEM: none
+
+class A {
+    val NaN = 0.3
+}
+
+fun test() {
+    val a = A()
+    val t = a.NaN ==<caret> 0.5
+}

--- a/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/simple.kt
+++ b/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/simple.kt
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test() {
+    val t = <caret>5.0 == Double.NaN
+}

--- a/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/simple.kt.after
+++ b/idea/testData/inspectionsLocal/convertEqualsDoubleNaN/simple.kt.after
@@ -1,0 +1,4 @@
+// WITH_RUNTIME
+fun test() {
+    val t = 5.0.isNaN()
+}

--- a/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
+++ b/idea/tests/org/jetbrains/kotlin/idea/inspections/LocalInspectionTestGenerated.java
@@ -2002,6 +2002,44 @@ public class LocalInspectionTestGenerated extends AbstractLocalInspectionTest {
         }
     }
 
+    @TestMetadata("idea/testData/inspectionsLocal/convertEqualsDoubleNaN")
+    @TestDataPath("$PROJECT_ROOT")
+    @RunWith(JUnit3RunnerWithInners.class)
+    public static class ConvertEqualsDoubleNaN extends AbstractLocalInspectionTest {
+        private void runTest(String testDataFilePath) throws Exception {
+            KotlinTestUtils.runTest(this::doTest, TargetBackend.ANY, testDataFilePath);
+        }
+
+        public void testAllFilesPresentInConvertEqualsDoubleNaN() throws Exception {
+            KotlinTestUtils.assertAllTestsPresentByMetadata(this.getClass(), new File("idea/testData/inspectionsLocal/convertEqualsDoubleNaN"), Pattern.compile("^([\\w\\-_]+)\\.(kt|kts)$"), TargetBackend.ANY, true);
+        }
+
+        @TestMetadata("importedProperty.kt")
+        public void testImportedProperty() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertEqualsDoubleNaN/importedProperty.kt");
+        }
+
+        @TestMetadata("inequality.kt")
+        public void testInequality() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertEqualsDoubleNaN/inequality.kt");
+        }
+
+        @TestMetadata("javaDouble.kt")
+        public void testJavaDouble() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertEqualsDoubleNaN/javaDouble.kt");
+        }
+
+        @TestMetadata("negative.kt")
+        public void testNegative() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertEqualsDoubleNaN/negative.kt");
+        }
+
+        @TestMetadata("simple.kt")
+        public void testSimple() throws Exception {
+            runTest("idea/testData/inspectionsLocal/convertEqualsDoubleNaN/simple.kt");
+        }
+    }
+
     @TestMetadata("idea/testData/inspectionsLocal/convertPairConstructorToToFunction")
     @TestDataPath("$PROJECT_ROOT")
     @RunWith(JUnit3RunnerWithInners.class)


### PR DESCRIPTION
YouTrack: https://youtrack.jetbrains.com/issue/KT-26629

Converts `5.0 == Double.NaN` to ` 5.0.equals(Double.NaN)`.